### PR TITLE
fix toolchain makefile to prevent repeated patching of crosstool-ng

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -35,8 +35,10 @@ all: .toolchain_prepared
 	$(TOP)/downloads/$(GLIBC_ARCH) \
 	$(TOP)/downloads/$(KERNEL_ARCH) \
 	$(TOP)/downloads/$(CROSS_ARCH)
-	tar -C $(TOP)/cross/$(TARGET) -xf $(TOP)/downloads/$(CROSS_ARCH)
-	patch -d $(TOP)/cross/$(TARGET)/$(CROSS) -p1 < crosstool-ng-from-trunc.patch
+	[ -d $(TOP)/cross/$(TARGET)/$(CROSS) ] || ( \
+		tar -C $(TOP)/cross/$(TARGET) -xf $(TOP)/downloads/$(CROSS_ARCH) && \
+		patch -d $(TOP)/cross/$(TARGET)/$(CROSS) -p1 < crosstool-ng-from-trunc.patch \
+	)
 	( \
 		cd $(TOP)/cross/$(TARGET)/$(CROSS) && \
 		./bootstrap && \


### PR DESCRIPTION
crosstool-ng was being patched every time 'make' was run in entware-arm in a way that the patch files for gcc 4.8.4 were being duplicated at every occurrence. Therefore any run past the first would fail to patch gcc. fixed by ensuring that crosstool-ng is not extracted and patched if it already exists.
